### PR TITLE
fix: fix reward and fee cut format

### DIFF
--- a/exporters/orch_info_exporter/orch_info_exporter.go
+++ b/exporters/orch_info_exporter/orch_info_exporter.go
@@ -243,12 +243,22 @@ func (m *OrchInfoExporter) updateMetrics() {
 	util.ParseFloatAndSetGauge(m.orchInfo.PageProps.Account.Protocol.CurrentRound.Id, m.CurrentRound)
 	util.ParseFloatAndSetGauge(m.orchInfo.PageProps.Account.Transcoder.ActivationRound, m.ActivationRound)
 	m.Active.Set(util.BoolToFloat64(m.orchInfo.PageProps.Account.Transcoder.Active))
-	util.ParseFloatAndSetGauge(m.orchInfo.PageProps.Account.Transcoder.FeeShare, m.FeeCut)
-	util.ParseFloatAndSetGauge(m.orchInfo.PageProps.Account.Transcoder.RewardCut, m.RewardCut)
 	util.ParseFloatAndSetGauge(m.orchInfo.PageProps.Account.Transcoder.LastRewardRound.Id, m.LastRewardRound)
 	util.ParseFloatAndSetGauge(m.orchInfo.PageProps.Account.Transcoder.NinetyDayVolumeETH, m.NinetyDayVolumeETH)
 	util.ParseFloatAndSetGauge(m.orchInfo.PageProps.Account.Transcoder.ThirtyDayVolumeETH, m.ThirtyDayVolumeETH)
 	util.ParseFloatAndSetGauge(m.orchInfo.PageProps.Account.Transcoder.TotalVolumeETH, m.TotalVolumeETH)
+
+	// Convert the fee cut and reward cut to fractions.
+	feeCut, err := strconv.ParseFloat(m.orchInfo.PageProps.Account.Transcoder.FeeShare, 64)
+	if err != nil {
+		log.Printf("Error parsing FeeShare: %v", err)
+	}
+	rewardCut, err := strconv.ParseFloat(m.orchInfo.PageProps.Account.Transcoder.RewardCut, 64)
+	if err != nil {
+		log.Printf("Error parsing RewardCut: %v", err)
+	}
+	m.FeeCut.Set(util.Round(1-feeCut*1e-6, 2))
+	m.RewardCut.Set(util.Round(rewardCut*1e-6, 2))
 
 	// Calculate and set the total LPT reward received by the orchestrator.
 	totalReward := 0.0

--- a/util/helpers.go
+++ b/util/helpers.go
@@ -3,6 +3,7 @@ package util
 
 import (
 	"log"
+	"math"
 	"strconv"
 
 	"github.com/prometheus/client_golang/prometheus"
@@ -25,4 +26,10 @@ func ParseFloatAndSetGauge(value string, gauge prometheus.Gauge) {
 		return
 	}
 	gauge.Set(parsed)
+}
+
+// Round rounds a float64 to a given number of decimal places.
+func Round(value float64, decimals int) float64 {
+	shift := math.Pow(10, float64(decimals))
+	return math.Round(value*shift) / shift
 }


### PR DESCRIPTION
This commit ensures that the reward and fee cut are displayed as
fractions.
