### PR TITLE
feat: add reward call ratio

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Fetches metrics about the Livepeer orchestrator from the [Livepeer Orchestrator 
 - `livepeer_orch_total_volume_eth`: Total volume of ETH.
 - `livepeer_orch_total_reward`: Total reward of the orchestrator.
 - `livepeer_orch_stake`: Stake provided by the orchestrator.
+- `livepeer_orch_reward_call_ratio`: Ratio of reward calls to total active rounds.
 
 ### orch_score_exporter
 

--- a/util/helpers.go
+++ b/util/helpers.go
@@ -18,9 +18,20 @@ func BoolToFloat64(b bool) float64 {
 	return 0.0
 }
 
+// StringToFloat64 parses a string to a float64.
+// If the string cannot be parsed, it returns an error.
+func StringToFloat64(s string) (float64, error) {
+	f, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		log.Printf("Error parsing value %v: %v", s, err)
+		return 0.0, err
+	}
+	return f, nil
+}
+
 // ParseFloatAndSetGauge parses a string to a float64 and sets the value of the given gauge.
 func ParseFloatAndSetGauge(value string, gauge prometheus.Gauge) {
-	parsed, err := strconv.ParseFloat(value, 64)
+	parsed, err := StringToFloat64(value)
 	if err != nil {
 		log.Printf("Error parsing value %v: %v", value, err)
 		return


### PR DESCRIPTION
This pull request introduces the `livepeer_orch_reward_call_ratio` metric, representing the ratio of reward calls to total active rounds by the orchestrator.