### PR TITLE
fix: fix reward call ratio calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,9 @@ Fetches metrics about the Livepeer orchestrator from the [Livepeer Orchestrator 
 - `livepeer_orch_ninety_day_volume_eth`: 90-day volume of ETH.
 - `livepeer_orch_thirty_day_volume_eth`: 30-day volume of ETH.
 - `livepeer_orch_total_volume_eth`: Total volume of ETH.
-- `livepeer_orch_total_reward`: Total reward of the orchestrator.
 - `livepeer_orch_stake`: Stake provided by the orchestrator.
 - `livepeer_orch_reward_call_ratio`: Ratio of reward calls to total active rounds.
+- `livepeer_orch_total_reward`: Total reward of the orchestrator.
 
 ### orch_score_exporter
 

--- a/exporters/orch_score_exporter/orch_score_exporter.go
+++ b/exporters/orch_score_exporter/orch_score_exporter.go
@@ -1,4 +1,5 @@
-// Package orch_score_exporter implements a Livepeer Orchestrator Score exporter that fetches data from the Livepeer orchestrator score API and exposes orchestrator score data via Prometheus metrics.
+// Package orch_score_exporter implements a Livepeer Orchestrator Score exporter that fetches data from the Livepeer orchestrator
+// score API and exposes orchestrator score data via Prometheus metrics.
 package orch_score_exporter
 
 import (

--- a/main.go
+++ b/main.go
@@ -86,15 +86,15 @@ func main() {
 		}
 	}
 
-	// Setup exporters.
-	log.Println("Setting up exporters...")
+	// Setup sub-exporters.
+	log.Println("Setting up sub exporters...")
 	orchInfoExporter := orch_info_exporter.NewOrchInfoExporter(orchAddr, fetchInterval, updateInterval, orchAddrSecondary)
 	orchScoreExporter := orch_score_exporter.NewOrchScoreExporter(orchAddr, fetchInterval, updateInterval)
 	orchDelegatorsExporter := orch_delegators_exporter.NewOrchDelegatorsExporter(orchAddr, fetchInterval, updateInterval)
 	orchTestStreamsExporter := orch_test_streams_exporter.NewOrchTestStreamsExporter(orchAddr, fetchTestStreamsInterval, updateInterval)
 
-	// Start exporters.
-	log.Println("Starting exporters...")
+	// Start sub-exporters.
+	log.Println("Starting sub exporters...")
 	orchInfoExporter.Start()
 	orchScoreExporter.Start()
 	orchDelegatorsExporter.Start()
@@ -103,5 +103,5 @@ func main() {
 	// Expose the registered metrics via HTTP.
 	log.Println("Exposing metrics via HTTP on port 9153")
 	http.Handle("/metrics", promhttp.Handler())
-	http.ListenAndServe(":9153", nil)
+	http.ListenAndServe(":9154", nil)
 }

--- a/util/helpers.go
+++ b/util/helpers.go
@@ -5,8 +5,6 @@ import (
 	"log"
 	"math"
 	"strconv"
-
-	"github.com/prometheus/client_golang/prometheus"
 )
 
 // BoolToFloat64 converts a bool to a float64.
@@ -18,29 +16,33 @@ func BoolToFloat64(b bool) float64 {
 	return 0.0
 }
 
+// Round rounds a float64 to a given number of decimal places.
+func Round(value float64, decimals int) float64 {
+	shift := math.Pow(10, float64(decimals))
+	return math.Round(value*shift) / shift
+}
+
 // StringToFloat64 parses a string to a float64.
 // If the string cannot be parsed, it returns an error.
 func StringToFloat64(s string) (float64, error) {
 	f, err := strconv.ParseFloat(s, 64)
 	if err != nil {
 		log.Printf("Error parsing value %v: %v", s, err)
-		return 0.0, err
 	}
-	return f, nil
+	return f, err
 }
 
-// ParseFloatAndSetGauge parses a string to a float64 and sets the value of the given gauge.
-func ParseFloatAndSetGauge(value string, gauge prometheus.Gauge) {
-	parsed, err := StringToFloat64(value)
+// SetFloatFromStr sets the value of a float64 pointer from a string.
+// If the string cannot be parsed to a float64, it logs an error and returns.
+// If significance is not -1, it rounds the float64 to the given number of decimal places.
+func SetFloatFromStr(dest *float64, source string, significance int) {
+	temp, err := StringToFloat64(source)
 	if err != nil {
-		log.Printf("Error parsing value %v: %v", value, err)
+		log.Printf("Error parsing string to float: %v", err)
 		return
 	}
-	gauge.Set(parsed)
-}
-
-// Round rounds a float64 to a given number of decimal places.
-func Round(value float64, decimals int) float64 {
-	shift := math.Pow(10, float64(decimals))
-	return math.Round(value*shift) / shift
+	if significance != -1 {
+		temp = Round(temp, significance)
+	}
+	*dest = temp
 }


### PR DESCRIPTION
This pull request ensures the reward call ratio does not show 0% when something goes wrong while parsing the data returned from the orchestrator info API.
