### PR TITLE
feat: add orchestrator tickets sub-exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This exporter comprises the following sub-exporters, each responsible for fetchi
 - [orch_info_exporter](./exporters/orch_info_exporter/): Collects metrics pertaining to the Livepeer orchestrator.
 - [orch_score_exporter](./exporters/orch_score_exporter/): Retrieves metrics concerning the Livepeer orchestrator's score.
 - [orch_test_streams_exporter](./exporters/orch_test_streams_exporter/): Procures metrics about the Livepeer orchestrator's test streams.
+- [orch_tickets_exporter](./exporters/orch_tickets_exporter/): Fetches metrics about the Livepeer orchestrator's tickets.
 
 These sub-exporters operate concurrently in separate [goroutines](https://go.dev/tour/concurrency/1) for enhanced performance. They fetch metrics from various Livepeer endpoints and expose them via the `9153/metrics` endpoint. For detailed information about these sub-exporters and the metrics they provide, refer to the sections below.
 
@@ -83,6 +84,17 @@ Fetches metrics about the LivePeer orchestrator's test streams from the https://
 - `livepeer_orch_test_stream_transcode_time`: Transcode time per region for test streams. This GaugeVec contains the labels `region` and `orchestrator`.
 - `livepeer_orch_test_stream_round_trip_time`: Round trip time per region for test streams. This GaugeVec contains the labels `region` and `orchestrator`.
 
+### orch_tickets_exporter
+
+Fetches and exposes ticket transaction information for each orchestrator from the https://stronk.rocks/api/livepeer/getAllRedeemTicketEvents API endpoint. The exposed metrics include:
+
+**GaugeVec metrics:**
+
+- `livepeer_orch_winning_ticket_amount`: Fees won by each winning orchestrator ticket. It contains the label `id`, which represents the unique identifier of each ticket.
+- `livepeer_orch_winning_ticket_transaction_hash`: Transaction hash for each winning ticket. The `id` label is a unique identifier of the transaction in which the ticket was won.
+- `livepeer_orch_winning_ticket_block_number`: Block number for each winning ticket. The `id` label is a unique identifier of the transaction in which the ticket was won.
+- `livepeer_orch_winning_ticket_block_time`: Block time for each winning ticket. The `id` label is a unique identifier of the transaction in which the ticket was won.
+  
 ## Configuration
 
 The exporter is configured via environment variables:
@@ -126,7 +138,7 @@ docker run --name livepeer-exporter \
 This command will start the exporter and expose the metrics on port `9153` for Prometheus to scrape. Additional environment variables can be passed to the exporter by adding them to the command above.
 
 > [!NOTE]
-> This repository provides a [Dockerfile](./Dockerfile) and a [docker-compose](./docker-compose.yml) file to facilitate running the exporter with Docker. To utilize these, ensure to first configure the necessary environment variables within the docker-compose file. Subsequently, initiate the exporter using the command `docker-compose up`.
+> This repository provides a [Dockerfile](./Dockerfile) and a [docker-compose](./docker-compose.yml) file to facilitate running the exporter with Docker. To utilize these, first configure the necessary environment variables within the docker-compose file. Subsequently, initiate the exporter using the command `docker-compose up`.
 
 ### Configure Prometheus
 

--- a/exporters/orch_delegators_exporter/orch_delegators_exporter.go
+++ b/exporters/orch_delegators_exporter/orch_delegators_exporter.go
@@ -109,7 +109,7 @@ func NewOrchDelegatorsExporter(orchAddress string, fetchInterval time.Duration, 
 	// Initialize fetcher.
 	exporter.orchDelegatorsFetcher = fetcher.Fetcher{
 		URL:  exporter.orchDelegatorsEndpoint,
-		Data: exporter.orchDelegators,
+		Data: &exporter.orchDelegators,
 	}
 
 	// Initialize metrics.

--- a/exporters/orch_info_exporter/orch_info_exporter.go
+++ b/exporters/orch_info_exporter/orch_info_exporter.go
@@ -357,12 +357,12 @@ func NewOrchInfoExporter(orchAddress string, fetchInterval time.Duration, update
 	// Initialize fetcher.
 	exporter.orchInfoFetcher = fetcher.Fetcher{
 		URL:  exporter.orchInfoEndpoint,
-		Data: exporter.orchInfoResponse,
+		Data: &exporter.orchInfoResponse,
 	}
 	if orchAddrSecondary != "" {
 		exporter.delegatingInfoFetcher = fetcher.Fetcher{
 			URL:  exporter.delegatingInfoEndpoint,
-			Data: exporter.delegatingInfoResponse,
+			Data: &exporter.delegatingInfoResponse,
 		}
 	}
 

--- a/exporters/orch_score_exporter/orch_score_exporter.go
+++ b/exporters/orch_score_exporter/orch_score_exporter.go
@@ -120,7 +120,7 @@ func NewOrchScoreExporter(orchAddress string, fetchInterval time.Duration, updat
 	// Initialize fetcher.
 	exporter.orchScoreFetcher = fetcher.Fetcher{
 		URL:  exporter.orchInfoEndpoint,
-		Data: exporter.orchScore,
+		Data: &exporter.orchScore,
 	}
 
 	// Initialize metrics.

--- a/exporters/orch_test_streams_exporter/orch_test_streams_exporter.go
+++ b/exporters/orch_test_streams_exporter/orch_test_streams_exporter.go
@@ -133,7 +133,7 @@ func NewOrchTestStreamsExporter(orchAddress string, fetchInterval time.Duration,
 	// Initialize fetcher.
 	exporter.orchTestStreamsFetcher = fetcher.Fetcher{
 		URL:  exporter.orchTestStreamsEndpoint,
-		Data: exporter.orchTestStreams,
+		Data: &exporter.orchTestStreams,
 	}
 
 	// Initialize metrics.

--- a/exporters/orch_tickets_exporter.go/orch_tickets_exporter.go
+++ b/exporters/orch_tickets_exporter.go/orch_tickets_exporter.go
@@ -1,0 +1,169 @@
+// Package orch_tickets_exporter implements a Livepeer Orchestrator Tickets exporter that fetches data from the https://stronk.rocks/api/livepeer/getAllRedeemTicketEvents API endpoint and exposes information about the orchestrator's tickets via Prometheus metrics.
+package orch_tickets_exporter
+
+import (
+	"livepeer-exporter/fetcher"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	getRedeemedTicketsEndpoint = "https://stronk.rocks/api/livepeer/getAllRedeemTicketEvents"
+)
+
+// TicketTransaction represents the structure of the ticket transaction field contained in the API response.
+type TicketTransaction struct {
+	Address         string
+	Amount          float64
+	TransactionHash string
+	BlockNumber     int
+	BlockTime       int
+}
+
+// Tickets represents the structure of the data returned by the API.
+type Tickets struct {
+	sync.Mutex
+
+	// Response data.
+	Transactions []TicketTransaction
+}
+
+// OrchTicketsExporter fetches data from the  API endpoint and exposes data about the orchestrator's tickets via Prometheus metrics.
+type OrchTicketsExporter struct {
+	// Metrics.
+	WinningTicketAmount          *prometheus.GaugeVec
+	WinningTicketTransactionHash *prometheus.GaugeVec
+	WinningTicketBlockNumber     *prometheus.GaugeVec
+	WinningTicketBlockTime       *prometheus.GaugeVec
+
+	// Config settings.
+	orchAddress         string        // The orchestrator address to filter tickets by.
+	fetchInterval       time.Duration // How often to fetch data.
+	updateInterval      time.Duration // How often to update metrics.
+	orchTicketsEndpoint string        // The endpoint to fetch data from.
+
+	// Data.
+	orchTickets *Tickets // The data returned by the API.
+
+	// Fetchers.
+	orchTicketsFetcher fetcher.Fetcher
+}
+
+// initMetrics initializes the orchestrator tickets metrics.
+func (m *OrchTicketsExporter) initMetrics() {
+	m.WinningTicketAmount = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "livepeer_orch_winning_ticket_amount",
+			Help: "The amount of fees won by each ticket.",
+		},
+		[]string{"id"},
+	)
+	m.WinningTicketTransactionHash = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "livepeer_orch_winning_ticket_transaction_hash",
+			Help: "The transaction hash for each winning ticket.",
+		},
+		[]string{"id"},
+	)
+	m.WinningTicketBlockNumber = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "livepeer_orch_winning_ticket_block_number",
+			Help: "The block number for each winning ticket.",
+		},
+		[]string{"id"},
+	)
+	m.WinningTicketBlockTime = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "livepeer_orch_winning_ticket_block_time",
+			Help: "The block time for each winning ticket.",
+		},
+		[]string{"id"},
+	)
+}
+
+// registerMetrics registers the orchestrator tickets metrics with Prometheus.
+func (m *OrchTicketsExporter) registerMetrics() {
+	prometheus.MustRegister(
+		m.WinningTicketAmount,
+		m.WinningTicketTransactionHash,
+		m.WinningTicketBlockNumber,
+		m.WinningTicketBlockTime,
+	)
+}
+
+// updateMetrics updates the metrics with the data fetched from the stonk.rocks tickets API.
+func (m *OrchTicketsExporter) updateMetrics() {
+	// Filter out tickets that are not for the configured orchestrator.
+	var tickets []TicketTransaction
+	for _, ticket := range m.orchTickets.Transactions {
+		if ticket.Address == m.orchAddress {
+			tickets = append(tickets, ticket)
+		}
+	}
+
+	// Set the metrics for each ticket.
+	for _, ticket := range tickets {
+		amount, _ := strconv.ParseFloat(strconv.FormatFloat(ticket.Amount, 'f', -1, 64), 64)
+		blockNumber, _ := strconv.ParseFloat(strconv.Itoa(ticket.BlockNumber), 64)
+		blockTime, _ := strconv.ParseFloat(strconv.Itoa(ticket.BlockTime), 64)
+
+		m.WinningTicketAmount.WithLabelValues(ticket.TransactionHash).Set(amount)
+		m.WinningTicketBlockNumber.WithLabelValues(ticket.TransactionHash).Set(blockNumber)
+		m.WinningTicketBlockTime.WithLabelValues(ticket.TransactionHash).Set(blockTime)
+	}
+}
+
+// NewOrchTicketsExporter creates a new OrchTicketsExporter.
+func NewOrchTicketsExporter(orchAddress string, fetchInterval time.Duration, updateInterval time.Duration) *OrchTicketsExporter {
+	exporter := &OrchTicketsExporter{
+		orchAddress:         orchAddress,
+		fetchInterval:       fetchInterval,
+		updateInterval:      updateInterval,
+		orchTicketsEndpoint: getRedeemedTicketsEndpoint,
+		orchTickets:         &Tickets{},
+	}
+
+	// Initialize fetcher.
+	exporter.orchTicketsFetcher = fetcher.Fetcher{
+		URL:  exporter.orchTicketsEndpoint,
+		Data: &exporter.orchTickets.Transactions,
+	}
+
+	// Initialize metrics.
+	exporter.initMetrics()
+	exporter.registerMetrics()
+
+	return exporter
+}
+
+// Start starts the OrchTicketsExporter.
+func (m *OrchTicketsExporter) Start() {
+	// Fetch initial data and update metrics.
+	m.orchTicketsFetcher.FetchDataWithBody(`{"smartUpdate":false}`)
+	m.updateMetrics()
+
+	// Start fetcher in a goroutine.
+	go func() {
+		ticker := time.NewTicker(m.fetchInterval)
+		defer ticker.Stop()
+
+		for range ticker.C {
+			m.orchTickets.Mutex.Lock()
+			m.orchTicketsFetcher.FetchDataWithBody(`{"smartUpdate":false}`)
+			m.orchTickets.Mutex.Unlock()
+		}
+	}()
+
+	// Start metrics updater in a goroutine.
+	go func() {
+		ticker := time.NewTicker(m.updateInterval)
+		defer ticker.Stop()
+
+		for range ticker.C {
+			m.updateMetrics()
+		}
+	}()
+}

--- a/main.go
+++ b/main.go
@@ -18,6 +18,7 @@ import (
 	"livepeer-exporter/exporters/orch_info_exporter"
 	"livepeer-exporter/exporters/orch_score_exporter"
 	"livepeer-exporter/exporters/orch_test_streams_exporter"
+	"livepeer-exporter/exporters/orch_tickets_exporter.go"
 	"log"
 	"net/http"
 	"os"
@@ -92,6 +93,7 @@ func main() {
 	orchScoreExporter := orch_score_exporter.NewOrchScoreExporter(orchAddr, fetchInterval, updateInterval)
 	orchDelegatorsExporter := orch_delegators_exporter.NewOrchDelegatorsExporter(orchAddr, fetchInterval, updateInterval)
 	orchTestStreamsExporter := orch_test_streams_exporter.NewOrchTestStreamsExporter(orchAddr, fetchTestStreamsInterval, updateInterval)
+	orchTicketsExporter := orch_tickets_exporter.NewOrchTicketsExporter(orchAddr, fetchInterval, updateInterval)
 
 	// Start sub-exporters.
 	log.Println("Starting sub exporters...")
@@ -99,6 +101,7 @@ func main() {
 	orchScoreExporter.Start()
 	orchDelegatorsExporter.Start()
 	orchTestStreamsExporter.Start()
+	orchTicketsExporter.Start()
 
 	// Expose the registered metrics via HTTP.
 	log.Println("Exposing metrics via HTTP on port 9153")


### PR DESCRIPTION
This pull request adds a new exporter that exports data about orchestrator tickets. Currently, it exposes the orchestrator's winning tickets.
