### PR TITLE
fix: make blocktime grafana compatible

### DIFF
--- a/exporters/orch_rewards_exporter/orch_rewards_exporter.go
+++ b/exporters/orch_rewards_exporter/orch_rewards_exporter.go
@@ -112,7 +112,7 @@ func (m *OrchRewardsExporter) updateMetrics() {
 
 		m.RewardAmount.WithLabelValues(reward.TransactionHash).Set(amount)
 		m.RewardBlockNumber.WithLabelValues(reward.TransactionHash).Set(blockNumber)
-		m.RewardBlockTime.WithLabelValues(reward.TransactionHash).Set(blockTime)
+		m.RewardBlockTime.WithLabelValues(reward.TransactionHash).Set(blockTime * 1000) // Grafana expects milliseconds.
 	}
 }
 

--- a/exporters/orch_tickets_exporter/orch_tickets_exporter.go
+++ b/exporters/orch_tickets_exporter/orch_tickets_exporter.go
@@ -112,7 +112,7 @@ func (m *OrchTicketsExporter) updateMetrics() {
 
 		m.WinningTicketAmount.WithLabelValues(ticket.TransactionHash).Set(amount)
 		m.WinningTicketBlockNumber.WithLabelValues(ticket.TransactionHash).Set(blockNumber)
-		m.WinningTicketBlockTime.WithLabelValues(ticket.TransactionHash).Set(blockTime)
+		m.WinningTicketBlockTime.WithLabelValues(ticket.TransactionHash).Set(blockTime * 1000) // Grafana expects milliseconds.
 	}
 }
 


### PR DESCRIPTION
This pull request standardizes the blocktime units to milliseconds for Ticket and Rewards exporters, ensuring compatibility with Grafana's expectations.