### PR TITLE
refactor: change orchestrator score range

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,9 +81,9 @@ Fetches metrics about the Livepeer orchestrator's score from the [Livepeer Score
 
 **GaugeVec metrics:**
 
-- `livepeer_orch_success_rates`: Success rates per region. This GaugeVec contains the label `region`.
-- `livepeer_orch_round_trip_scores`: Round trip scores per region. This GaugeVec contains the label `region`.
-- `livepeer_orch_scores`: Scores per region. This GaugeVec contains the label `region`.
+- `livepeer_orch_success_rate`: Success rate per region. This GaugeVec contains the label `region`.
+- `livepeer_orch_round_trip_score`: Round trip score per region. This GaugeVec contains the label `region`.
+- `livepeer_orch_total_score`: Total score per region. This GaugeVec contains the label `region`.
 
 ### orch_test_streams_exporter
 

--- a/exporters/orch_score_exporter/orch_score_exporter.go
+++ b/exporters/orch_score_exporter/orch_score_exporter.go
@@ -56,22 +56,22 @@ func (m *OrchScoreExporter) initMetrics() {
 	)
 	m.SuccessRates = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "livepeer_orch_success_rates",
-			Help: "The success rates per region.",
+			Name: "livepeer_orch_success_rate",
+			Help: "The success rate per region.",
 		},
 		[]string{"region"},
 	)
 	m.RoundTripScores = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "livepeer_orch_round_trip_scores",
-			Help: "The round trip scores per region.",
+			Name: "livepeer_orch_round_trip_score",
+			Help: "The round trip score per region.",
 		},
 		[]string{"region"},
 	)
 	m.Scores = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "livepeer_orch_scores",
-			Help: "The scores per region.",
+			Name: "livepeer_orch_total_score",
+			Help: "The total score per region.",
 		},
 		[]string{"region"},
 	)
@@ -99,12 +99,12 @@ func (m *OrchScoreExporter) updateMetrics() {
 
 	// Update the RoundTripScores metric
 	for region, score := range m.orchScore.RoundTripScores {
-		m.RoundTripScores.WithLabelValues(region).Set(score)
+		m.RoundTripScores.WithLabelValues(region).Set(score / 10)
 	}
 
 	// Update the Scores metric
 	for region, score := range m.orchScore.Scores {
-		m.Scores.WithLabelValues(region).Set(score)
+		m.Scores.WithLabelValues(region).Set(score / 10)
 	}
 }
 


### PR DESCRIPTION
This pull request ensures that the orchestrator scores are between 0-10 to improve consistency with the explorer. Also, the score variable names were changed from plural to singular to be more descriptive.
