### PR TITLE
feat: add crypto prices exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Before using the Livepeer Exporter, you must configure it using environment vari
 - `LIVEPEER_EXPORTER_TEST_STREAMS_UPDATE_INTERVAL`: How often to update the orchestrator test streams metrics. Defaults to the value of `LIVEPEER_EXPORTER_TEST_STREAMS_FETCH_INTERVAL`.
 - `LIVEPEER_EXPORTER_TICKETS_UPDATE_INTERVAL`: How often to update the orchestrator tickets metrics. Defaults to the value of `LIVEPEER_EXPORTER_TICKETS_FETCH_INTERVAL`.
 - `LIVEPEER_EXPORTER_REWARDS_UPDATE_INTERVAL`: How often to update the orchestrator rewards metrics. Defaults to the value of `LIVEPEER_EXPORTER_REWARDS_FETCH_INTERVAL`.
+- `CRYPTO_PRICES_EXPORTER_FETCH_INTERVAL`: How often to fetch the crypto prices. Defaults to `1m`.
+- `CRYPTO_PRICES_EXPORTER_UPDATE_INTERVAL`: How often to update the crypto prices metrics. Defaults to the value of `CRYPTO_PRICES_EXPORTER_FETCH_INTERVAL`.
 
 All intervals are specified as a string representation of a duration, e.g., "5m" for 5 minutes, "2h" for 2 hours, etc. See [time#ParseDuration](https://pkg.go.dev/time#ParseDuration) for format details.
 
@@ -87,16 +89,26 @@ This configuration tells Prometheus to scrape metrics from the Livepeer Exporter
 
 This exporter comprises the following sub-exporters, each responsible for fetching specific metrics:
 
-| Sub-Exporter | Description |
-| --- | --- |
-| [orch_delegators_exporter](./exporters/orch_delegators_exporter/) | Gathers metrics related to the delegators of the designated Livepeer orchestrator. |
-| [orch_info_exporter](./exporters/orch_info_exporter/) | Collects metrics pertaining to the Livepeer orchestrator. |
-| [orch_reward_exporter](./exporters/orch_reward_exporter/) | Retrieves metrics about the Livepeer orchestrator's rewards. |
-| [orch_score_exporter](./exporters/orch_score_exporter/) | Retrieves metrics concerning the Livepeer orchestrator's score. |
-| [orch_test_streams_exporter](./exporters/orch_test_streams_exporter/) | Procures metrics about the Livepeer orchestrator's test streams. |
-| [orch_tickets_exporter](./exporters/orch_tickets_exporter/) | Fetches metrics about the Livepeer orchestrator's tickets. |
+| Sub-Exporter                                                          | Description                                                                                            |
+| --------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ |
+| [crypto_prices_exporter](./exporters/crypto_prices_exporter/)         | Fetches and exposes the prices of different cryptocurrencies used in the Livepeer ecosystem. |
+| [orch_delegators_exporter](./exporters/orch_delegators_exporter/)     | Gathers metrics related to the delegators of the designated Livepeer orchestrator.                     |
+| [orch_info_exporter](./exporters/orch_info_exporter/)                 | Collects metrics pertaining to the Livepeer orchestrator.                                              |
+| [orch_reward_exporter](./exporters/orch_reward_exporter/)             | Retrieves metrics about the Livepeer orchestrator's rewards.                                           |
+| [orch_score_exporter](./exporters/orch_score_exporter/)               | Retrieves metrics concerning the Livepeer orchestrator's score.                                        |
+| [orch_test_streams_exporter](./exporters/orch_test_streams_exporter/) | Procures metrics about the Livepeer orchestrator's test streams.                                       |
+| [orch_tickets_exporter](./exporters/orch_tickets_exporter/)           | Fetches metrics about the Livepeer orchestrator's tickets.                                             |
 
 For enhanced performance, these sub-exporters operate concurrently in separate [goroutines](https://go.dev/tour/concurrency/1). They fetch metrics from various Livepeer endpoints and expose them via the `9153/metrics` endpoint. For detailed information about these sub-exporters and the metrics they provide, refer to the sections below.
+
+### Crypto Prices Exporter
+
+The `crypto_prices_exporter` fetches and exposes the prices of different cryptocurrencies used in the Livepeer ecosystem. They include:
+
+**GaugeVec metrics:**
+
+- `LPT_price`: This metric represents the current price of the LPT token. This GaugeVec includes the label `currency`, representing the currency of the price (e.g., `USD`, `EUR`, etc.)
+- `ETH_price`: This metric represents the current price of Ethereum. This GaugeVec includes the label `currency`, representing the currency of the price (e.g., `USD`, `EUR`, etc.)
 
 ### orch_delegators_exporter
 

--- a/exporters/crypto_prices_exporter/crypto_prices_exporter.go
+++ b/exporters/crypto_prices_exporter/crypto_prices_exporter.go
@@ -1,0 +1,163 @@
+// Package crypto_prices_exporter implements a crypto prices exporter that fetches data from the https://api.coinbase.com/v2/exchange-rates?currency=USD API endpoint and exposes information about several crypto currencies that
+// are relevant to Livepeer.
+package crypto_prices_exporter
+
+import (
+	"livepeer-exporter/fetcher"
+	"livepeer-exporter/util"
+	"log"
+	"sync"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+var (
+	getCryptoPricesEndpoint = "https://api.coinbase.com/v2/exchange-rates?currency=USD"
+)
+
+// CryptoPricesResponse represents the structure of the data returned by the API.
+type CryptoPricesResponse struct {
+	sync.Mutex
+
+	Data struct {
+		Currency string
+		Rates    map[string]string `json:"rates"`
+	}
+}
+
+// cryptoPrices represents the structure of the data returned by the API, parsed into a struct.
+type cryptoPrices struct {
+	LPTUSDPrice float64
+	ETHUSDPrice float64
+	LPTEURPrice float64
+	ETHEURPrice float64
+}
+
+// CryptoPricesExporter fetches data from the  API endpoint and exposes data about the crypto prices via Prometheus metrics.
+type CryptoPricesExporter struct {
+	// Metrics.
+	LPTPrice *prometheus.GaugeVec
+	ETHPrice *prometheus.GaugeVec
+
+	// Config settings.
+	fetchInterval        time.Duration // How often to fetch data.
+	updateInterval       time.Duration // How often to update metrics.
+	cryptoPricesEndpoint string        // The endpoint to fetch data from.
+
+	// Data.
+	cryptoPricesResponse *CryptoPricesResponse // The data returned by the API.
+	cryptoPrices         *cryptoPrices         // The data returned by the  API, parsed into a struct.
+
+	// Fetchers.
+	cryptoPricesFetcher fetcher.Fetcher
+}
+
+// initMetrics initializes the crypto prices metrics.
+func (m *CryptoPricesExporter) initMetrics() {
+	m.LPTPrice = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "LPT_price",
+		Help: "LPT token price.",
+	}, []string{"currency"})
+	m.ETHPrice = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "ETH_price",
+		Help: "Ethereum  price.",
+	}, []string{"currency"})
+}
+
+// registerMetrics registers the crypto prices metrics with Prometheus.
+func (m *CryptoPricesExporter) registerMetrics() {
+	prometheus.MustRegister(
+		m.LPTPrice,
+		m.ETHPrice,
+	)
+}
+
+// parseMetrics parses the values from the cryptoResponse and populates the cryptoPricesResponse struct.
+func (m *CryptoPricesExporter) parseMetrics() {
+	// Retrieve dollar prices.
+	LPTUSDPrice, err := util.StringToFloat64(m.cryptoPricesResponse.Data.Rates["LPT"])
+	if err != nil {
+		log.Printf("Error trying to parse LPT price: %v", err)
+		return
+	}
+	ETHUSDPrice, err := util.StringToFloat64(m.cryptoPricesResponse.Data.Rates["ETH"])
+	if err != nil {
+		log.Printf("Error trying to parse ETH price: %v", err)
+		return
+	}
+	m.cryptoPrices.LPTUSDPrice = 1 / LPTUSDPrice
+	m.cryptoPrices.ETHUSDPrice = 1 / ETHUSDPrice
+
+	// Calculate prices in euros.
+	USDToEUR, err := util.StringToFloat64(m.cryptoPricesResponse.Data.Rates["EUR"])
+	if err != nil {
+		log.Printf("Error trying to parse USD to EUR conversion rate: %v", err)
+		return
+	}
+	m.cryptoPrices.LPTEURPrice = m.cryptoPrices.LPTUSDPrice * USDToEUR
+	m.cryptoPrices.ETHEURPrice = m.cryptoPrices.ETHUSDPrice * USDToEUR
+}
+
+// updateMetrics updates the metrics with the data fetched from the Coinbase exchange-rates API.
+func (m *CryptoPricesExporter) updateMetrics() {
+	// Parse the metrics from the response data.
+	m.parseMetrics()
+
+	// Set the metrics.
+	m.LPTPrice.WithLabelValues("USD").Set(m.cryptoPrices.LPTUSDPrice)
+	m.LPTPrice.WithLabelValues("EUR").Set(m.cryptoPrices.LPTEURPrice)
+	m.ETHPrice.WithLabelValues("USD").Set(m.cryptoPrices.ETHUSDPrice)
+	m.ETHPrice.WithLabelValues("EUR").Set(m.cryptoPrices.ETHEURPrice)
+}
+
+// NewCryptoPricesExporter creates a new CryptoPricesExporter.
+func NewCryptoPricesExporter(fetchInterval time.Duration, updateInterval time.Duration) *CryptoPricesExporter {
+	exporter := &CryptoPricesExporter{
+		fetchInterval:        fetchInterval,
+		updateInterval:       updateInterval,
+		cryptoPricesEndpoint: getCryptoPricesEndpoint,
+		cryptoPricesResponse: &CryptoPricesResponse{},
+		cryptoPrices:         &cryptoPrices{},
+	}
+
+	// Initialize fetcher.
+	exporter.cryptoPricesFetcher = fetcher.Fetcher{
+		URL:  exporter.cryptoPricesEndpoint,
+		Data: &exporter.cryptoPricesResponse,
+	}
+
+	// Initialize metrics.
+	exporter.initMetrics()
+	exporter.registerMetrics()
+
+	return exporter
+}
+
+func (m *CryptoPricesExporter) Start() {
+	// Fetch initial data and update metrics.
+	m.cryptoPricesFetcher.FetchData()
+	m.updateMetrics()
+
+	// Start fetchers in a goroutine.
+	go func() {
+		ticker := time.NewTicker(m.fetchInterval)
+		defer ticker.Stop()
+
+		for range ticker.C {
+			m.cryptoPricesResponse.Mutex.Lock()
+			m.cryptoPricesFetcher.FetchData()
+			m.cryptoPricesResponse.Mutex.Unlock()
+		}
+	}()
+
+	// Start metrics updater in a goroutine.
+	go func() {
+		ticker := time.NewTicker(m.updateInterval)
+		defer ticker.Stop()
+
+		for range ticker.C {
+			m.updateMetrics()
+		}
+	}()
+}

--- a/exporters/orch_info_exporter/orch_info_exporter.go
+++ b/exporters/orch_info_exporter/orch_info_exporter.go
@@ -254,7 +254,7 @@ func (m *OrchInfoExporter) registerMetrics() {
 	)
 }
 
-// parseMetrics parses the metrics from the orchInfoResponse and delegatingInfoResponse and populates the orchInfo struct.
+// parseMetrics parses the values from the orchInfoResponse and delegatingInfoResponse and populates the orchInfo struct.
 func (m *OrchInfoExporter) parseMetrics() {
 	// Parse and set the orchestrator info.
 	util.SetFloatFromStr(&m.orchInfo.BondedAmount, m.orchInfoResponse.PageProps.Account.Delegator.BondedAmount)

--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@
 package main
 
 import (
+	"livepeer-exporter/exporters/crypto_prices_exporter"
 	"livepeer-exporter/exporters/orch_delegators_exporter"
 	"livepeer-exporter/exporters/orch_info_exporter"
 	"livepeer-exporter/exporters/orch_rewards_exporter"
@@ -46,6 +47,7 @@ var (
 	testStreamsFetchIntervalDefault = 1 * time.Hour
 	ticketsFetchIntervalDefault     = 1 * time.Hour
 	rewardsFetchIntervalDefault     = 12 * time.Hour
+	cryptoPricesFetchInterval       = 1 * time.Minute
 )
 
 // Default config values.
@@ -68,6 +70,7 @@ func main() {
 	testStreamFetchInterval := util.GetEnvDuration("LIVEPEER_EXPORTER_TEST_STREAMS_FETCH_INTERVAL", testStreamsFetchIntervalDefault)
 	ticketsFetchInterval := util.GetEnvDuration("LIVEPEER_EXPORTER_TICKETS_FETCH_INTERVAL", ticketsFetchIntervalDefault)
 	rewardsFetchInterval := util.GetEnvDuration("LIVEPEER_EXPORTER_REWARDS_FETCH_INTERVAL", rewardsFetchIntervalDefault)
+	cryptoPricesFetchInterval := util.GetEnvDuration("LIVEPEER_EXPORTER_CRYPTO_PRICES_FETCH_INTERVAL", cryptoPricesFetchInterval)
 
 	// Retrieve update intervals.
 	infoUpdateInterval := util.GetEnvDuration("LIVEPEER_EXPORTER_INFO_UPDATE_INTERVAL", infoFetchInterval)
@@ -76,6 +79,7 @@ func main() {
 	testStreamUpdateInterval := util.GetEnvDuration("LIVEPEER_EXPORTER_TEST_STREAMS_UPDATE_INTERVAL", testStreamFetchInterval)
 	ticketsUpdateInterval := util.GetEnvDuration("LIVEPEER_EXPORTER_TICKETS_UPDATE_INTERVAL", ticketsFetchInterval)
 	rewardsUpdateInterval := util.GetEnvDuration("LIVEPEER_EXPORTER_REWARDS_UPDATE_INTERVAL", rewardsFetchInterval)
+	cryptoPricesUpdateInterval := util.GetEnvDuration("LIVEPEER_EXPORTER_CRYPTO_PRICES_UPDATE_INTERVAL", cryptoPricesFetchInterval)
 
 	// Setup sub-exporters.
 	log.Println("Setting up sub exporters...")
@@ -85,6 +89,7 @@ func main() {
 	orchTestStreamsExporter := orch_test_streams_exporter.NewOrchTestStreamsExporter(orchAddr, testStreamFetchInterval, testStreamUpdateInterval)
 	orchTicketsExporter := orch_tickets_exporter.NewOrchTicketsExporter(orchAddr, ticketsFetchInterval, ticketsUpdateInterval)
 	orchRewardsExporter := orch_rewards_exporter.NewOrchRewardsExporter(orchAddr, rewardsFetchInterval, rewardsUpdateInterval)
+	cryptoPricesExporter := crypto_prices_exporter.NewCryptoPricesExporter(cryptoPricesFetchInterval, cryptoPricesUpdateInterval)
 
 	// Start sub-exporters.
 	log.Println("Starting sub exporters...")
@@ -94,6 +99,7 @@ func main() {
 	go orchTestStreamsExporter.Start()
 	go orchTicketsExporter.Start()
 	go orchRewardsExporter.Start()
+	go cryptoPricesExporter.Start()
 
 	// Expose the registered metrics via HTTP.
 	log.Println("Exposing metrics via HTTP on port 9153")


### PR DESCRIPTION
This pull request adds the Crypto Prices exporter, which fetches prices of several cryptocurrencies used in the Livepeer ecosystem from the Coinbase exchange-rates API and publishes them on Prometheus metrics.
