### PR TITLE
refactor: change default metrics update interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,15 +28,15 @@ Before using the Livepeer Exporter, you must configure it using environment vari
 - `LIVEPEER_EXPORTER_TICKETS_FETCH_INTERVAL`: How often to fetch ticket data for the orchestrator. Defaults to `1h`.
 - `LIVEPEER_EXPORTER_REWARDS_FETCH_INTERVAL`: How often to fetch rewards data for the orchestrator. Defaults to `12h`.
 - `CRYPTO_PRICES_EXPORTER_FETCH_INTERVAL`: How often to fetch the crypto prices. Defaults to `1m`.
-- `LIVEPEER_EXPORTER_INFO_UPDATE_INTERVAL`: How often to update the orchestrator info metrics. Defaults to the value of `LIVEPEER_EXPORTER_INFO_FETCH_INTERVAL`.
-- `LIVEPEER_EXPORTER_SCORE_UPDATE_INTERVAL`: How often to update the orchestrator score metrics. Defaults to the value of `LIVEPEER_EXPORTER_SCORE_FETCH_INTERVAL`.
-- `LIVEPEER_EXPORTER_DELEGATORS_UPDATE_INTERVAL`: How often to update the orchestrator delegators metrics. Defaults to the value of `LIVEPEER_EXPORTER_DELEGATORS_FETCH_INTERVAL`.
-- `LIVEPEER_EXPORTER_TEST_STREAMS_UPDATE_INTERVAL`: How often to update the orchestrator test streams metrics. Defaults to the value of `LIVEPEER_EXPORTER_TEST_STREAMS_FETCH_INTERVAL`.
-- `LIVEPEER_EXPORTER_TICKETS_UPDATE_INTERVAL`: How often to update the orchestrator tickets metrics. Defaults to the value of `LIVEPEER_EXPORTER_TICKETS_FETCH_INTERVAL`.
-- `LIVEPEER_EXPORTER_REWARDS_UPDATE_INTERVAL`: How often to update the orchestrator rewards metrics. Defaults to the value of `LIVEPEER_EXPORTER_REWARDS_FETCH_INTERVAL`.
-- `CRYPTO_PRICES_EXPORTER_UPDATE_INTERVAL`: How often to update the crypto prices metrics. Defaults to the value of `CRYPTO_PRICES_EXPORTER_FETCH_INTERVAL`.
+- `LIVEPEER_EXPORTER_INFO_UPDATE_INTERVAL`: How often to update the orchestrator info metrics.  Defaults to `30s`.
+- `LIVEPEER_EXPORTER_SCORE_UPDATE_INTERVAL`: How often to update the orchestrator score metrics. Defaults to `30s`.
+- `LIVEPEER_EXPORTER_DELEGATORS_UPDATE_INTERVAL`: How often to update the orchestrator delegators metrics.  Defaults to `30s`.
+- `LIVEPEER_EXPORTER_TEST_STREAMS_UPDATE_INTERVAL`: How often to update the orchestrator test streams metrics.  Defaults to `30s`.
+- `LIVEPEER_EXPORTER_TICKETS_UPDATE_INTERVAL`: How often to update the orchestrator tickets metrics. Defaults to `30s`.
+- `LIVEPEER_EXPORTER_REWARDS_UPDATE_INTERVAL`: How often to update the orchestrator rewards metrics.  Defaults to `30s`.
+- `CRYPTO_PRICES_EXPORTER_UPDATE_INTERVAL`: How often to update the crypto prices metrics. Defaults to `30s`.
 
-All intervals are specified as a string representation of a duration, e.g., "5m" for 5 minutes, "2h" for 2 hours, etc. See [time#ParseDuration](https://pkg.go.dev/time#ParseDuration) for format details.
+All intervals are specified as a string representation of a duration, e.g., `5m`` for 5 minutes, `2h` for 2 hours, etc. See [time#ParseDuration](https://pkg.go.dev/time#ParseDuration) for format details.
 
 > [!NOTE]\
 > The `LIVEPEER_EXPORTER_TEST_STREAMS_FETCH_INTERVAL`, `LIVEPEER_EXPORTER_TICKETS_FETCH_INTERVAL`, and `LIVEPEER_EXPORTER_REWARDS_FETCH_INTERVAL`environment variables have higher default values. This adjustment is made considering the nature of the endpoints they fetch—they might be slow or return a substantial amount of data. By setting these values to a higher interval, you can effectively reduce the load on the exporter, ensuring optimal performance.

--- a/main.go
+++ b/main.go
@@ -48,6 +48,15 @@ var (
 	ticketsFetchIntervalDefault     = 1 * time.Hour
 	rewardsFetchIntervalDefault     = 12 * time.Hour
 	cryptoPricesFetchInterval       = 1 * time.Minute
+
+	// Update intervals.
+	infoUpdateIntervalDefault         = 30 * time.Second
+	scoreUpdateIntervalDefault        = 30 * time.Second
+	delegatorsUpdateIntervalDefault   = 30 * time.Second
+	testStreamsUpdateIntervalDefault  = 30 * time.Second
+	ticketsUpdateIntervalDefault      = 30 * time.Second
+	rewardsUpdateIntervalDefault      = 30 * time.Second
+	cryptoPricesUpdateIntervalDefault = 30 * time.Second
 )
 
 // Default config values.
@@ -73,13 +82,13 @@ func main() {
 	cryptoPricesFetchInterval := util.GetEnvDuration("LIVEPEER_EXPORTER_CRYPTO_PRICES_FETCH_INTERVAL", cryptoPricesFetchInterval)
 
 	// Retrieve update intervals.
-	infoUpdateInterval := util.GetEnvDuration("LIVEPEER_EXPORTER_INFO_UPDATE_INTERVAL", infoFetchInterval)
-	scoreUpdateInterval := util.GetEnvDuration("LIVEPEER_EXPORTER_SCORE_UPDATE_INTERVAL", scoreFetchInterval)
-	delegatorsUpdateInterval := util.GetEnvDuration("LIVEPEER_EXPORTER_DELEGATORS_UPDATE_INTERVAL", delegatorsFetchInterval)
-	testStreamUpdateInterval := util.GetEnvDuration("LIVEPEER_EXPORTER_TEST_STREAMS_UPDATE_INTERVAL", testStreamFetchInterval)
-	ticketsUpdateInterval := util.GetEnvDuration("LIVEPEER_EXPORTER_TICKETS_UPDATE_INTERVAL", ticketsFetchInterval)
-	rewardsUpdateInterval := util.GetEnvDuration("LIVEPEER_EXPORTER_REWARDS_UPDATE_INTERVAL", rewardsFetchInterval)
-	cryptoPricesUpdateInterval := util.GetEnvDuration("LIVEPEER_EXPORTER_CRYPTO_PRICES_UPDATE_INTERVAL", cryptoPricesFetchInterval)
+	infoUpdateInterval := util.GetEnvDuration("LIVEPEER_EXPORTER_INFO_UPDATE_INTERVAL", infoUpdateIntervalDefault)
+	scoreUpdateInterval := util.GetEnvDuration("LIVEPEER_EXPORTER_SCORE_UPDATE_INTERVAL", scoreUpdateIntervalDefault)
+	delegatorsUpdateInterval := util.GetEnvDuration("LIVEPEER_EXPORTER_DELEGATORS_UPDATE_INTERVAL", delegatorsUpdateIntervalDefault)
+	testStreamUpdateInterval := util.GetEnvDuration("LIVEPEER_EXPORTER_TEST_STREAMS_UPDATE_INTERVAL", testStreamsUpdateIntervalDefault)
+	ticketsUpdateInterval := util.GetEnvDuration("LIVEPEER_EXPORTER_TICKETS_UPDATE_INTERVAL", ticketsUpdateIntervalDefault)
+	rewardsUpdateInterval := util.GetEnvDuration("LIVEPEER_EXPORTER_REWARDS_UPDATE_INTERVAL", rewardsUpdateIntervalDefault)
+	cryptoPricesUpdateInterval := util.GetEnvDuration("LIVEPEER_EXPORTER_CRYPTO_PRICES_UPDATE_INTERVAL", cryptoPricesUpdateIntervalDefault)
 
 	// Setup sub-exporters.
 	log.Println("Setting up sub exporters...")


### PR DESCRIPTION
This pull request changes the default interval used to update the metrics of the sub-exporters to increase consistency between the data of the different exporters.