### PR TITLE
mitigate racing conditions

### DIFF
--- a/exporters/crypto_prices_exporter/crypto_prices_exporter.go
+++ b/exporters/crypto_prices_exporter/crypto_prices_exporter.go
@@ -1,5 +1,6 @@
-// Package crypto_prices_exporter implements a crypto prices exporter that fetches data from the https://api.coinbase.com/v2/exchange-rates?currency=USD API endpoint and exposes information about several crypto currencies that
-// are relevant to Livepeer.
+// Package crypto_prices_exporter implements a crypto prices exporter that fetches data from the
+// https://api.coinbase.com/v2/exchange-rates?currency=USD API endpoint and exposes information
+// about several crypto currencies that are relevant to Livepeer.
 package crypto_prices_exporter
 
 import (
@@ -16,8 +17,8 @@ var (
 	getCryptoPricesEndpoint = "https://api.coinbase.com/v2/exchange-rates?currency=USD"
 )
 
-// CryptoPricesResponse represents the structure of the data returned by the API.
-type CryptoPricesResponse struct {
+// cryptoPricesResponse represents the structure of the data returned by the API.
+type cryptoPricesResponse struct {
 	sync.Mutex
 
 	Data struct {
@@ -34,7 +35,7 @@ type cryptoPrices struct {
 	ETHEURPrice float64
 }
 
-// CryptoPricesExporter fetches data from the  API endpoint and exposes data about the crypto prices via Prometheus metrics.
+// CryptoPricesExporter fetches data from the API and exposes data about the crypto prices via Prometheus metrics.
 type CryptoPricesExporter struct {
 	// Metrics.
 	LPTPrice *prometheus.GaugeVec
@@ -46,7 +47,7 @@ type CryptoPricesExporter struct {
 	cryptoPricesEndpoint string        // The endpoint to fetch data from.
 
 	// Data.
-	cryptoPricesResponse *CryptoPricesResponse // The data returned by the API.
+	cryptoPricesResponse *cryptoPricesResponse // The data returned by the API.
 	cryptoPrices         *cryptoPrices         // The data returned by the  API, parsed into a struct.
 
 	// Fetchers.
@@ -102,7 +103,9 @@ func (m *CryptoPricesExporter) parseMetrics() {
 // updateMetrics updates the metrics with the data fetched from the Coinbase exchange-rates API.
 func (m *CryptoPricesExporter) updateMetrics() {
 	// Parse the metrics from the response data.
+	m.cryptoPricesResponse.Mutex.Lock()
 	m.parseMetrics()
+	m.cryptoPricesResponse.Mutex.Unlock()
 
 	// Set the metrics.
 	m.LPTPrice.WithLabelValues("USD").Set(m.cryptoPrices.LPTUSDPrice)
@@ -117,7 +120,7 @@ func NewCryptoPricesExporter(fetchInterval time.Duration, updateInterval time.Du
 		fetchInterval:        fetchInterval,
 		updateInterval:       updateInterval,
 		cryptoPricesEndpoint: getCryptoPricesEndpoint,
-		cryptoPricesResponse: &CryptoPricesResponse{},
+		cryptoPricesResponse: &cryptoPricesResponse{},
 		cryptoPrices:         &cryptoPrices{},
 	}
 

--- a/exporters/orch_delegators_exporter/orch_delegators_exporter.go
+++ b/exporters/orch_delegators_exporter/orch_delegators_exporter.go
@@ -1,4 +1,6 @@
-// Package orch_delegators_exporter implements a Livepeer Orchestrator Delegators exporter that fetches data from the https://stronk.rocks/api/livepeer/getOrchestrator/ API endpoint and exposes information about the orchestrator's delegators via Prometheus metrics.
+// Package orch_delegators_exporter implements a Livepeer orchestrator elegators exporter that
+// fetches data from the https://stronk.rocks/api/livepeer/getOrchestrator/ API endpoint and exposes
+// information about the orchestrator's delegators via Prometheus metrics.
 package orch_delegators_exporter
 
 import (
@@ -15,22 +17,22 @@ var (
 	orchDelegatorsEndpointTemplate = "https://stronk.rocks/api/livepeer/getOrchestrator/%s"
 )
 
-// Delegator represents the structure of the delegators field contained in the API response.
-type Delegator struct {
+// delegator represents the structure of the delegators field contained in the API response.
+type delegator struct {
 	ID           string
 	BondedAmount string
 	StartRound   string
 }
 
-// OrchDelegators represents the structure of the data returned by the API.
-type OrchDelegators struct {
+// orchDelegators represents the structure of the data returned by the API.
+type orchDelegators struct {
 	sync.Mutex
 
 	// Response data.
-	Delegators []Delegator
+	Delegators []delegator
 }
 
-// OrchDelegatorsExporter fetches data from the  API endpoint and exposes data about the orchestrator's delegators via Prometheus metrics.
+// OrchDelegatorsExporter fetches data from the API and exposes orchestrator's delegators metrics via Prometheus.
 type OrchDelegatorsExporter struct {
 	// Metrics.
 	BondedAmount   *prometheus.GaugeVec
@@ -43,7 +45,7 @@ type OrchDelegatorsExporter struct {
 	orchDelegatorsEndpoint string        // The endpoint to fetch data from.
 
 	// Data.
-	orchDelegators *OrchDelegators // The data returned by the API.
+	orchDelegators *orchDelegators // The data returned by the API.
 
 	// Fetchers.
 	orchDelegatorsFetcher fetcher.Fetcher
@@ -103,7 +105,7 @@ func NewOrchDelegatorsExporter(orchAddress string, fetchInterval time.Duration, 
 		fetchInterval:          fetchInterval,
 		updateInterval:         updateInterval,
 		orchDelegatorsEndpoint: fmt.Sprintf(orchDelegatorsEndpointTemplate, orchAddress),
-		orchDelegators:         &OrchDelegators{},
+		orchDelegators:         &orchDelegators{},
 	}
 
 	// Initialize fetcher.
@@ -143,7 +145,9 @@ func (m *OrchDelegatorsExporter) Start() {
 		defer ticker.Stop()
 
 		for range ticker.C {
+			m.orchDelegators.Mutex.Lock()
 			m.updateMetrics()
+			m.orchDelegators.Mutex.Unlock()
 		}
 	}()
 }

--- a/exporters/orch_info_exporter/orch_info_exporter.go
+++ b/exporters/orch_info_exporter/orch_info_exporter.go
@@ -1,5 +1,5 @@
-// Package orch_info_exporter implements a Livepeer Orchestrator Info exporter that fetches data from Livepeer's orchestrator info API and exposes
-// info about the orchestrator via Prometheus metrics.
+// Package orch_info_exporter implements a Livepeer orchestrator info exporter that fetches data
+// from Livepeer's orchestrator info API and exposes info about the orchestrator via Prometheus metrics.
 package orch_info_exporter
 
 import (
@@ -18,8 +18,8 @@ var (
 	delegatingInfoEndpointTemplate = "https://explorer.livepeer.org/_next/data/xe8lg6V7gubXcRErA1lxB/accounts/%s/delegating.json?account=%s"
 )
 
-// OrchInfoResponse represents the structure of the data returned by the Livepeer orchestrator info API.
-type OrchInfoResponse struct {
+// orchInfoResponse represents the structure of the data returned by the Livepeer orchestrator info API.
+type orchInfoResponse struct {
 	Mutex sync.Mutex
 
 	// Response data.
@@ -60,8 +60,8 @@ type OrchInfoResponse struct {
 	}
 }
 
-// OrchInfo represents the parsed data from the Livepeer orchestrator info API.
-type OrchInfo struct {
+// orchInfo represents the parsed data from the Livepeer orchestrator info API.
+type orchInfo struct {
 	BondedAmount       float64
 	TotalStake         float64
 	LastClaimRound     float64
@@ -80,9 +80,9 @@ type OrchInfo struct {
 	RewardCallRatio    float64
 }
 
-// DelegationInfoResponse represents the structure of the data returned by the Livepeer delegator info API. This is used to fetch extra delegation
+// delegationInfoResponse represents the structure of the data returned by the Livepeer delegator info API. This is used to fetch extra delegation
 // data for the orchestrator when the `LIVEPEER_EXPORTER_ORCHESTRATOR_ADDRESS_SECONDARY` environment variable is set.
-type DelegationInfoResponse struct {
+type delegationInfoResponse struct {
 	Mutex sync.Mutex
 
 	// Response data.
@@ -95,7 +95,7 @@ type DelegationInfoResponse struct {
 	}
 }
 
-// OrchInfoExporter fetches data from the Livepeer orchestrator info API and exposes info about the orchestrator via Prometheus metrics.
+// OrchInfoExporter fetches data from the API and exposes orchestrator info via Prometheus.
 type OrchInfoExporter struct {
 	// Metrics.
 	BondedAmount       prometheus.Gauge
@@ -123,9 +123,9 @@ type OrchInfoExporter struct {
 	delegatingInfoEndpoint string        // The endpoint to fetch extra delegation data from.
 
 	// Data.
-	orchInfoResponse       *OrchInfoResponse       // The data returned by the orchestrator API.
-	delegatingInfoResponse *DelegationInfoResponse // The data returned by the delegation API.
-	orchInfo               *OrchInfo               // The data returned by the orchestrator API, parsed into a struct.
+	orchInfoResponse       *orchInfoResponse       // The data returned by the orchestrator API.
+	delegatingInfoResponse *delegationInfoResponse // The data returned by the delegation API.
+	orchInfo               *orchInfo               // The data returned by the orchestrator API, parsed into a struct.
 
 	// Fetchers.
 	orchInfoFetcher       fetcher.Fetcher
@@ -310,7 +310,9 @@ func (m *OrchInfoExporter) parseMetrics() {
 // updateMetrics updates the metrics with the data fetched from the Livepeer orchestrator info API.
 func (m *OrchInfoExporter) updateMetrics() {
 	// Parse the metrics from the response data.
+	m.orchInfoResponse.Mutex.Lock()
 	m.parseMetrics()
+	m.orchInfoResponse.Mutex.Unlock()
 
 	// Set the metrics.
 	m.BondedAmount.Set(m.orchInfo.BondedAmount)
@@ -339,9 +341,9 @@ func NewOrchInfoExporter(orchAddress string, fetchInterval time.Duration, update
 		orchAddressSecondary:   orchAddrSecondary,
 		orchInfoEndpoint:       fmt.Sprintf(orchInfoEndpointTemplate, orchAddress, orchAddress),
 		delegatingInfoEndpoint: fmt.Sprintf(delegatingInfoEndpointTemplate, orchAddrSecondary, orchAddrSecondary),
-		orchInfoResponse:       &OrchInfoResponse{},
-		delegatingInfoResponse: &DelegationInfoResponse{},
-		orchInfo:               &OrchInfo{},
+		orchInfoResponse:       &orchInfoResponse{},
+		delegatingInfoResponse: &delegationInfoResponse{},
+		orchInfo:               &orchInfo{},
 	}
 
 	// Initialize fetcher.

--- a/exporters/orch_score_exporter/orch_score_exporter.go
+++ b/exporters/orch_score_exporter/orch_score_exporter.go
@@ -1,5 +1,5 @@
-// Package orch_score_exporter implements a Livepeer Orchestrator Score exporter that fetches data from the Livepeer orchestrator
-// score API and exposes orchestrator score data via Prometheus metrics.
+// Package orch_score_exporter implements a Livepeer orchestrator score exporter that fetches data
+// from the Livepeer orchestrator score API and exposes orchestrator score data via Prometheus metrics.
 package orch_score_exporter
 
 import (
@@ -15,8 +15,8 @@ var (
 	orchScoreEndpointTemplate = "https://explorer.livepeer.org/api/score/%s"
 )
 
-// OrchScore represents the structure of the data returned by the Livepeer orchestrator score API.
-type OrchScore struct {
+// orchScore represents the structure of the data returned by the Livepeer orchestrator score API.
+type orchScore struct {
 	Mutex sync.Mutex
 
 	// Response data.
@@ -40,7 +40,7 @@ type OrchScoreExporter struct {
 	orchInfoEndpoint string        // The endpoint to fetch data from.
 
 	// Data.
-	orchScore *OrchScore // The data returned by the API.
+	orchScore *orchScore // The data returned by the API.
 
 	// Fetchers.
 	orchScoreFetcher fetcher.Fetcher
@@ -114,7 +114,7 @@ func NewOrchScoreExporter(orchAddress string, fetchInterval time.Duration, updat
 		fetchInterval:    fetchInterval,
 		updateInterval:   updateInterval,
 		orchInfoEndpoint: fmt.Sprintf(orchScoreEndpointTemplate, orchAddress),
-		orchScore:        &OrchScore{},
+		orchScore:        &orchScore{},
 	}
 
 	// Initialize fetcher.
@@ -154,7 +154,9 @@ func (m *OrchScoreExporter) Start() {
 		defer ticker.Stop()
 
 		for range ticker.C {
+			m.orchScore.Mutex.Lock()
 			m.updateMetrics()
+			m.orchScore.Mutex.Unlock()
 		}
 	}()
 }


### PR DESCRIPTION
This pull request adds extra mutex lock and unlock statements around the part where the response data is read. This needs to be done since the fetching and reading are done in seperate gorountines.
