### PR TITLE
fix: remove test stream update delay

### DIFF
--- a/exporters/orch_test_streams_exporter/orch_test_streams_exporter.go
+++ b/exporters/orch_test_streams_exporter/orch_test_streams_exporter.go
@@ -113,13 +113,12 @@ func (m *TestStreamsExporter) updateMetrics() {
 		{"SAO", m.orchTestStreams.SAO},
 		{"SIN", m.orchTestStreams.SIN},
 	} {
-		for _, orchData := range regionData.testStreams {
-			m.SuccessRate.WithLabelValues(regionData.Region, orchData.Orchestrator).Set(orchData.SuccessRate)
-			m.UploadTime.WithLabelValues(regionData.Region, orchData.Orchestrator).Set(orchData.UploadTime)
-			m.DownloadTime.WithLabelValues(regionData.Region, orchData.Orchestrator).Set(orchData.DownloadTime)
-			m.TranscodeTime.WithLabelValues(regionData.Region, orchData.Orchestrator).Set(orchData.TranscodeTime)
-			m.RoundTripTime.WithLabelValues(regionData.Region, orchData.Orchestrator).Set(orchData.RoundTripTime)
-		}
+		// Only use the first test stream data since it is the most recent.
+		m.SuccessRate.WithLabelValues(regionData.Region, regionData.testStreams[0].Orchestrator).Set(regionData.testStreams[0].SuccessRate)
+		m.UploadTime.WithLabelValues(regionData.Region, regionData.testStreams[0].Orchestrator).Set(regionData.testStreams[0].UploadTime)
+		m.DownloadTime.WithLabelValues(regionData.Region, regionData.testStreams[0].Orchestrator).Set(regionData.testStreams[0].DownloadTime)
+		m.TranscodeTime.WithLabelValues(regionData.Region, regionData.testStreams[0].Orchestrator).Set(regionData.testStreams[0].TranscodeTime)
+		m.RoundTripTime.WithLabelValues(regionData.Region, regionData.testStreams[0].Orchestrator).Set(regionData.testStreams[0].RoundTripTime)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -43,9 +43,9 @@ import (
 // Exporter default config values.
 var (
 	// Fetch intervals.
-	infoFetchIntevalDefault         = 1 * time.Minute
-	scoreFetchIntevalDefault        = 1 * time.Minute
-	delegatorsFetchIntevalDefault   = 5 * time.Minute
+	infoFetchIntervalDefault        = 1 * time.Minute
+	scoreFetchIntervalDefault       = 1 * time.Minute
+	delegatorsFetchIntervalDefault  = 5 * time.Minute
 	testStreamsFetchIntervalDefault = 1 * time.Hour
 	ticketsFetchIntervalDefault     = 1 * time.Hour
 	rewardsFetchIntervalDefault     = 1 * time.Hour
@@ -75,9 +75,9 @@ func main() {
 	orchAddrSecondary := os.Getenv("LIVEPEER_EXPORTER_ORCHESTRATOR_ADDRESS_SECONDARY")
 
 	// Retrieve fetch intervals.
-	infoFetchInterval := util.GetEnvDuration("LIVEPEER_EXPORTER_INFO_FETCH_INTERVAL", infoFetchIntevalDefault)
-	scoreFetchInterval := util.GetEnvDuration("LIVEPEER_EXPORTER_SCORE_FETCH_INTERVAL", scoreFetchIntevalDefault)
-	delegatorsFetchInterval := util.GetEnvDuration("LIVEPEER_EXPORTER_DELEGATORS_FETCH_INTERVAL", delegatorsFetchIntevalDefault)
+	infoFetchInterval := util.GetEnvDuration("LIVEPEER_EXPORTER_INFO_FETCH_INTERVAL", infoFetchIntervalDefault)
+	scoreFetchInterval := util.GetEnvDuration("LIVEPEER_EXPORTER_SCORE_FETCH_INTERVAL", scoreFetchIntervalDefault)
+	delegatorsFetchInterval := util.GetEnvDuration("LIVEPEER_EXPORTER_DELEGATORS_FETCH_INTERVAL", delegatorsFetchIntervalDefault)
 	testStreamFetchInterval := util.GetEnvDuration("LIVEPEER_EXPORTER_TEST_STREAMS_FETCH_INTERVAL", testStreamsFetchIntervalDefault)
 	ticketsFetchInterval := util.GetEnvDuration("LIVEPEER_EXPORTER_TICKETS_FETCH_INTERVAL", ticketsFetchIntervalDefault)
 	rewardsFetchInterval := util.GetEnvDuration("LIVEPEER_EXPORTER_REWARDS_FETCH_INTERVAL", rewardsFetchIntervalDefault)


### PR DESCRIPTION
This pull request ensures only the latest test stream data is set in Prometheus. In the old code, the oldest test stream ended up being set.
